### PR TITLE
Bug Fix: Last line of Note / comment was lost

### DIFF
--- a/src/main/java/com/wn/dbml/compiler/lexer/LexerImpl.java
+++ b/src/main/java/com/wn/dbml/compiler/lexer/LexerImpl.java
@@ -145,6 +145,7 @@ public class LexerImpl extends AbstractLexer {
 				sb.append((char) c);
 			}
 			if (lookahead.equals(quote)) {
+				multiLineSb.appendLine(sb.toString());
 				skipChars(quote.length());
 				break;
 			}


### PR DESCRIPTION
In case of a multi-line comment/note, the last line of the comment was omitted. 